### PR TITLE
Feat: 홈 대시보드 목표 컴포넌트 기능 구현(1차)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.11.0",
+        "lucide-react": "^0.542.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "react-router-dom": "^7.8.2",
         "zustand": "^5.0.8"
       },
       "devDependencies": {
@@ -2166,6 +2168,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3262,6 +3273,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.542.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.542.0.tgz",
+      "integrity": "sha512-w3hD8/SQB7+lzU2r4VdFyzzOzKnUjTZIF/MQJGSSvni7Llewni4vuViRppfRAa2guOsY5k4jZyxw/i9DQHv+dw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3820,6 +3840,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.2.tgz",
+      "integrity": "sha512-7M2fR1JbIZ/jFWqelpvSZx+7vd7UlBTfdZqf6OSdF9g6+sfdqJDAWcak6ervbHph200ePlu+7G8LdoiC3ReyAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.8.2.tgz",
+      "integrity": "sha512-Z4VM5mKDipal2jQ385H6UBhiiEDlnJPx6jyWsTYoZQdl5TrjxEV2a9yl3Fi60NBJxYzOTGTTHXPi0pdizvTwow==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.8.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -3964,6 +4022,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,10 @@
   },
   "dependencies": {
     "axios": "^1.11.0",
+    "lucide-react": "^0.542.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-router-dom": "^7.8.2",
     "zustand": "^5.0.8"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import BottomNav from './shared/components/common/BottomNav';
 import Home from './pages/home';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,20 @@
+import React from 'react';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import BottomNav from './shared/components/common/BottomNav';
+import Home from './pages/home';
+
 function App() {
   return (
     <div className="flex justify-center min-h-screen bg-gray-100">
-      <div className="w-full max-w-[480px] min-w-[320px] bg-white">
-        <h1>텅장메이트</h1>
+      <div className="w-full max-w-[480px] min-w-[320px] bg-white relative">
+        <Router>
+          <div className="App">
+            <Routes>
+              <Route path="/" element={<Home />} />
+            </Routes>
+            <BottomNav />
+          </div>
+        </Router>
       </div>
     </div>
   )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import Home from './pages/home';
 function App() {
   return (
     <div className="flex justify-center min-h-screen bg-gray-100">
-      <div className="w-full max-w-[480px] min-w-[320px] bg-white relative">
+      <div className="w-full max-w-[480px] min-w-[320px] bg-white relative px-6">
         <Router>
           <div className="App">
             <Routes>

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import HomeGoal from '../../shared/components/goal/homeGoal'
 
 function Home() {

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+function Home() {
+  return (
+    <div>안녕하세요 홈 대시보드입니다.</div>
+  )
+}
+
+export default Home

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,8 +1,11 @@
 import React from 'react'
+import HomeGoal from '../../shared/components/goal/homeGoal'
 
 function Home() {
   return (
-    <div>안녕하세요 홈 대시보드입니다.</div>
+    <div>
+      <HomeGoal />
+    </div>
   )
 }
 

--- a/src/shared/components/common/BottomNav.tsx
+++ b/src/shared/components/common/BottomNav.tsx
@@ -1,0 +1,75 @@
+import React from 'react'
+import { useNavigate, useLocation } from 'react-router'
+import {Home, Lightbulb, TrendingUp, User} from "lucide-react"
+
+interface NavItem {
+  path: string; 
+  icon: React.ReactNode;
+  label: string;
+}
+
+function BottomNav() {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const navItems: NavItem[] = [
+    {
+      path: '/',
+      icon: <Home size={24} />,
+      label: '홈',
+    },
+    {
+      path: '/strategy',
+      icon: <Lightbulb size={24} />,
+      label: '전략리스트',
+    },
+    {
+      path: '/analysis',
+      icon: <TrendingUp size={24} />,
+      label: '성취분석',
+    },
+    {
+      path: '/mypage',
+      icon: <User size={24} />,
+      label: '마이페이지',
+    },
+  ];
+
+  function handleNavClick(path: string) {
+    navigate(path);
+  }
+
+  return (
+    <nav className="absolute bottom-0 left-0 right-0 z-50 bg-white border-t border-gray-200">
+      <div className="max-w-md px-4 mx-auto">
+        <div className="flex items-center justify-around py-2">
+          {navItems.map((item) => {
+            const isActive = location.pathname === item.path;
+            return (
+              <button
+                key={item.path}
+                onClick={() => handleNavClick(item.path)}
+                className={`flex flex-col items-center py-2 px-3 rounded-lg transition-colors ${
+                  isActive 
+                    ? 'text-gray-700' 
+                    : 'text-gray-500 hover:text-gray-700'
+                }`}
+              >
+                <div className={`mb-1 ${isActive ? 'text-gray-700' : 'text-gray-500'}`}>
+                  {item.icon}
+                </div>
+                <span className={`text-xs font-medium ${
+                  isActive ? 'text-gray-700' : 'text-gray-500'
+                }`}>
+                  {item.label}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </nav>
+  )
+}
+
+export default BottomNav

--- a/src/shared/components/goal/homeGoal.tsx
+++ b/src/shared/components/goal/homeGoal.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 function homeGoal() {
   /**
    * 금액 포맷 함수 formatAmount

--- a/src/shared/components/goal/homeGoal.tsx
+++ b/src/shared/components/goal/homeGoal.tsx
@@ -1,0 +1,81 @@
+import React from 'react'
+
+function homeGoal() {
+  /**
+   * 금액 포맷 함수 formatAmount
+   * @param amount - 금액 숫자
+   * @returns 포맷된 금액 문자열 (예: 1,000원, 10,000원, 1만2,000원)
+   */
+  function formatAmount(amount: number) {
+    if(amount >= 10000) {
+      return `${Math.floor(amount / 10000)}만${amount % 10000 ? (amount % 10000).toLocaleString() : ''}원`;
+    }
+    return `${amount.toLocaleString()}원`;
+  }
+  // 임시 하드코딩 데이터
+  const targetAmount = 3000000; // 300만원
+  const monthlySalary = 2000000; // 월급 200만원
+  const savingRate = 0.1; // 저축률 10%
+  const monthlyTarget = monthlySalary * savingRate; // 월 저축 목표 (20만원)
+
+  // 목표 달성 기간 계산
+  const requiredSavings = Math.ceil(targetAmount / monthlyTarget); // 15회 저축 
+  const totalDays = (requiredSavings - 1) * 30; // 14개월 = 420일 (첫 저축은 오늘이므로 -1)
+  const shortenedDays = 121.5; // 전략 단축 기간(임시 300일)
+  const remainingDays = totalDays - shortenedDays; // 남은 기간 (450일)
+
+  // 진행률 계산 (단축된 일수 기준)
+    const percentage = (shortenedDays / totalDays) * 100; 
+
+  return (
+    <div className="mt-24 bg-white">
+      <div className="font-medium text-left">
+        <h1 className="text-gray-900 text-24">텅장메이트와</h1>
+      </div>
+
+      {/* 목표 금액 & D-day */}
+      <div className="mb-24 font-medium text-left">
+        <h2 className="text-24">
+          <span className="text-primary-200">{Math.floor(targetAmount / 10000)}</span>  
+          {/* 단위 변환 : 30,000원 -> 3만원 */}
+          <span className="text-gray-900">만원 모으기 </span>
+          {/* <span className="text-primary-200">D-{Math.round(remainingDays)}</span> */}
+          <span className="text-primary-200">D-{remainingDays}</span>
+        </h2>
+      </div>
+
+      {/* 한 달에 저금하기 */}
+      <div className="mb-8 text-left">
+        <p className="text-gray-500 text-14">한 달에 {formatAmount(monthlyTarget)}씩 저금하기</p>
+      </div>
+
+      {/* 진행률 바 */}
+      <div className="mb-4">
+        <div className="relative">
+          <div className="w-full h-[16px] bg-gray-100 rounded-4">
+            <div 
+              className="relative h-[16px] rounded-4 bg-primary-100"
+              style={{ width: `${Math.min(percentage, 100)}%`}}
+            >
+              {/* 아이콘 (진행 지점) */}
+              {percentage > 0 && (
+                <div className="absolute text-20 -right-3 -top-3">
+                  🐸
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 9월 저금 금액 10% 확보 */}
+      <div className="flex justify-start">
+        <div className="mt-2 px-2 py-0.5 text-white rounded-full bg-primary-100 text-12">
+          9월 저금 금액 10% 확보
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default homeGoal


### PR DESCRIPTION
### 🚀 변경 사항
<!-- 이번 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
Feat: 홈 대시보드 페이지 목표 컴포넌트 구현 #7 

### ✅ 체크리스트
- [x] Bottom Nav (임시) 기능 개발
- [x] 홈 대시보드 목표 섹션 컴포넌트 구현 
- [x] 페이지 라우팅 임시 세팅
- [ ] 코드 리뷰 완료
- [x] 테스트 통과 확인

### 💡 주요 변경 내용
- 저축 목표 금액 및 D-day 표시 기능(현재는 임시 데이터로 진행)
- 월별 저축 목표 및 진행률 바 구현(캐릭터 이모지로 임시 대체)


### 📸 스크린샷
<img width="379" height="297" alt="image" src="https://github.com/user-attachments/assets/ca94eb92-d783-4728-9e06-14618dc7ed8e" />

### 📎 관련 링크
- Closes #7 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduced client-side routing for smoother in-app navigation.
  * Added a fixed bottom navigation bar with icons: Home, Strategy List, Analysis, and My Page.
  * Implemented a new Home page featuring a goal-tracking widget with D-day, monthly target summary, and a progress indicator.
* Chores
  * Added dependencies to support routing and iconography.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->